### PR TITLE
support GH pages deployment

### DIFF
--- a/gulp-config.js
+++ b/gulp-config.js
@@ -14,7 +14,8 @@
     sass: themeDir,
     img: themeDir + '/images',
     dist_css: themeDir + '/dist/css',
-    dist_img: themeDir + '/dist/img'
+    dist_img: themeDir + '/dist/img',
+    pattern_lab: themeDir + '/pattern-lab/public'
   };
 
   module.exports = {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ module.exports = function(gulp, config) {
   // icons
   var svgSprite = require('gulp-svg-sprite');
 
+  // deploy
+  var ghPages = require('gulp-gh-pages');
+
   var tasks = {
     compile: [],
     watch: [],
@@ -123,5 +126,16 @@ module.exports = function(gulp, config) {
    * Theme task declaration
    */
   gulp.task('build', ['imagemin', 'clean', 'scripts', 'styleguide-scripts', 'css', 'icons']);
+
+  /**
+   * Deploy
+   */
+  gulp.task('deploy', function () {
+    return gulp.src([
+      config.paths.dist_js + '/**/*',
+      config.paths.pattern_lab + '/**/*'
+    ], { base: config.themeDir } )
+    .pipe(ghPages());
+  });
 
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gulp-clean-css": "^2.0.12",
     "gulp-concat": "^2.6.0",
     "gulp-flatten": "^0.2.0",
+    "gulp-gh-pages": "^0.5.4",
     "gulp-help": "^1.6.1",
     "gulp-if": "^2.0.1",
     "gulp-imagemin": "^2.4.0",


### PR DESCRIPTION
Adds support for deploying to github pages using `gulp deploy`. See working example here: https://fourkitchens.github.io/emulsify/pattern-lab/public/

Uses: https://www.npmjs.com/package/gulp-gh-pages