### PR TITLE
Skip 2.2.1 of sassdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node-normalize-scss": "^1.3.1",
     "node-notifier": "^4.6.0",
     "psi": "^2.0.4",
-    "sassdoc": "^2.1.20",
+    "sassdoc": "^2.1.20 != 2.2.1",
     "singularitygs": "^1.7.0",
     "webpagetest": "^0.3.4"
   }


### PR DESCRIPTION
Skipping 2.2.1 of sassdoc that has an issue that should be fixed in the next release.

The fix is already in a PR [in the sassdoc repo](https://github.com/SassDoc/sassdoc/pull/491), just waiting to be merged, so I think it's safe to just skip the one version.