### PR TITLE
Fixed sassdoc version operator

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node-normalize-scss": "^1.3.1",
     "node-notifier": "^4.6.0",
     "psi": "^2.0.4",
-    "sassdoc": "^2.1.20 != 2.2.1",
+    "sassdoc": "2.2.0 || ^2.2.2",
     "singularitygs": "^1.7.0",
     "webpagetest": "^0.3.4"
   }


### PR DESCRIPTION
Switched to the || operator since I don't think != is supported in package.json.