### PR TITLE
Allow sprites to be written to proper destination in node 7

### DIFF
--- a/gulp-config.js
+++ b/gulp-config.js
@@ -69,7 +69,7 @@
       mode: {
         css: {
           bust: false,
-          dest: '../../dist',
+          dest: 'dist',
           prefix: '@mixin sprite-%s',
           render: {
             scss: {

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = function(gulp, config) {
   gulp.task('icons', function () {
     return gulp.src('**/*.svg', {cwd: config.paths.img + '/icons/src'})
       .pipe(svgSprite(config.iconConfig))
-      .pipe(gulp.dest(config.themeDir + '/images/icons'));
+      .pipe(gulp.dest('./'));
   });
 
   tasks.compile.push('icons');


### PR DESCRIPTION
For some reason, my front-end developer and I were getting different results with the sprites generation. In Node 7, the sprites were being written to paths below `images/`, no matter the relative configuration of the paths in the default config. In Node 4, they were generated as expected.

I am not generally a Node developer but I suspect this has something to do with a jailing or security consideration? Regardless, an adjustment to the path in `gulp.dest()` does the trick.

Not suggesting this is the definitive fix, but this hopefully at least starts the conversation.