### PR TITLE
Fixing CSS Inject on Browser Reload

### DIFF
--- a/gulp-tasks/gulp-css.js
+++ b/gulp-tasks/gulp-css.js
@@ -44,6 +44,7 @@
       .pipe(gulpif(config.cssConfig.flattenDestOutput, flatten()))
       .pipe(gulp.dest(config.cssConfig.dest))
       .on('end', function () {
+        browserSync.reload('*.css');
         done();
       });
     }

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ module.exports = function(gulp, config) {
     }
     gulp.watch(config.paths.js, ['scripts']).on('change', browserSync.reload);
     gulp.watch(config.paths.styleguide_js, ['styleguide-scripts']).on('change', browserSync.reload);
-    gulp.watch(config.paths.sass + '/**/*.scss', ['css']).on('change', browserSync.reload);
+    gulp.watch(config.paths.sass + '/**/*.scss', ['css']);
   });
 
   /**


### PR DESCRIPTION
The previous implementation triggered a full page reload when sass files had changed which caused the page to load **before** the CSS was compiled so changes were not seen and would require another manual refresh. This fixes that by waiting to trigger reload until the CSS is compiled and adds the nice benefit of injecting the CSS changes without a page refresh resulting in a much faster development process. :beers: