### PR TITLE
Fixes browsersync for Twig/YML files (changing markup)

### DIFF
--- a/gulp-tasks/gulp-pattern-lab.js
+++ b/gulp-tasks/gulp-pattern-lab.js
@@ -14,7 +14,7 @@
   const yaml = require('js-yaml');
   const fs = require('fs');
 
-  module.exports = (gulp, config, {watch, compile}) => {
+  module.exports = (gulp, config, {watch, compile}, browserSync) => {
 
     const plConfig = yaml.safeLoad(
       fs.readFileSync(config.patternLab.configFile, 'utf8')

--- a/gulp-tasks/gulp-pattern-lab.js
+++ b/gulp-tasks/gulp-pattern-lab.js
@@ -28,7 +28,7 @@
     function plBuild(cb) {
       notifier.sh(`php ${consolePath} --generate`, true, () => {
         if (config.browserSync.enabled) {
-          browserSync.reload;
+          browserSync.reload('*.html');
         }
         cb();
       });
@@ -43,7 +43,7 @@
         console.log(`File ${path.relative(process.cwd(), event.path)} was ${event.type}, running tasks...`);
         notifier.sh(`php ${consolePath} --generate`, false, () => {
           if (config.browserSync.enabled) {
-            browserSync.reload;
+            browserSync.reload('*.html');
           }
         });
       });

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports = (gulp, config) => {
   tasks.compile.push('icons');
 
   // Pattern Lab
-  require('./gulp-tasks/gulp-pattern-lab.js')(gulp, config, tasks);
+  require('./gulp-tasks/gulp-pattern-lab.js')(gulp, config, tasks, browserSync);
 
   /**
    * Task for running browserSync.


### PR DESCRIPTION
Fixes https://github.com/fourkitchens/emulsify-gulp/issues/45

**To test:**
- [x] To what you need to do to make sure you're running this branch of emulsify-gulp (`fourkitchens/emulsify-gulp#plbrowsersync`) 
- [x] Open up any Twig file and edit it and make sure the component reloads to show you your changes.
- [x] Create a new Twig file (or duplicate another) and make sure the site reloads with your new file in the pattern lab menu
- [x] Open up any YML file and edit it and make sure the component reloads to show you your changes.
- [x] Make sure this didn't mess up anything else either (sass, js reloading)