### PR TITLE
Search for port and more

### DIFF
--- a/gulp-config.js
+++ b/gulp-config.js
@@ -84,16 +84,15 @@
       ]
     },
     browserSync: {
-      ui: false,
       enabled: true,
       baseDir: './',
-      startPath: `${themeDir}pattern-lab/public/`,
+      startPath: `pattern-lab/public/`,
       // Uncomment below if using a specific local url
       // domain: 'emulsify.dev',
-      openBrowserAtStart: true,
-      browser: "google chrome",
-      reloadDelay: 50,
-      reloadDebounce: 750
+      notify: false,
+      openBrowserAtStart: false,
+      reloadOnRestart: true,
+      ui: false,
     },
     wpt: {
       // WebPageTest API key https://www.webpagetest.org/getkey.php

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = (gulp, config) => {
   require('./gulp-tasks/gulp-pattern-lab.js')(gulp, config, tasks);
 
   // Find open port using portscanner.
-  var openPort = 3000;
+  let openPort = '';
   portscanner.findAPortNotInUse(3000, 3010, '127.0.0.1', function (error, port) {
     openPort = port;
   });

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = (gulp, config) => {
   require('./gulp-tasks/gulp-pattern-lab.js')(gulp, config, tasks);
 
   // Find open port using portscanner.
-  var openPort = '';
+  var openPort = 3000;
   portscanner.findAPortNotInUse(3000, 3010, '127.0.0.1', function (error, port) {
     openPort = port;
   });

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = (gulp, config) => {
   // General
   var gulp = require('gulp-help')(gulp);
   const _ = require('lodash');
+  const portscanner = require('portscanner');
   const browserSync = require('browser-sync').create();
   const defaultConfig = require('./gulp-config');
   var config = _.defaultsDeep(config, defaultConfig);
@@ -84,6 +85,12 @@ module.exports = (gulp, config) => {
   // Pattern Lab
   require('./gulp-tasks/gulp-pattern-lab.js')(gulp, config, tasks);
 
+  // Find open port using portscanner.
+  var openPort = '';
+  portscanner.findAPortNotInUse(3000, 3010, '127.0.0.1', function (error, port) {
+    openPort = port;
+  });
+
   /**
    * Task for running browserSync.
    */
@@ -102,7 +109,12 @@ module.exports = (gulp, config) => {
         server: {
           baseDir: config.browserSync.baseDir
         },
-        startPath: config.browserSync.startPath
+        startPath: config.browserSync.startPath,
+        notify: config.browserSync.notify,
+        ui: config.browserSync.ui,
+        open: config.browserSync.openBrowserAtStart,
+        reloadOnRestart: config.browserSync.reloadOnRestart,
+        port: openPort,
       });
     }
     gulp.watch(config.paths.js, ['scripts']).on('change', browserSync.reload);


### PR DESCRIPTION
Fixes https://github.com/fourkitchens/emulsify-gulp/issues/15

**Changes:**
- Searches for port using portscanner (instead of going to default 3000 every time)
- Adds all browsersync config items to index.js (some just weren't there)
- Sets browsersync ui, notify and open browser to false by default and sets reload on restart to true (I think these are better defaults, but feel free to critique). See below for more info.

[browsersync ui](https://www.browsersync.io/docs/options#option-ui)
[browsersync notify](https://www.browsersync.io/docs/options#option-notify)
[browsersync open](https://www.browsersync.io/docs/options#option-open)
[browsersync reloadonrestart](https://www.browsersync.io/docs/options#option-reloadOnRestart)

**To test:**
- [x] Open up two instances of Emulsify. On the first, you can test normally by npm/yarn installing and npm/yarn starting.
- [x] On the second, change the emulsify-gulp dep to this branch and npm install.
- [x] Run `npm start` and ensure that it runs on a separate port from the first and doesn't error out.
- [x] Also ensure you like the new browsersync default settings.