### PR TITLE
Colors YAML

### DIFF
--- a/gulp-config.js
+++ b/gulp-config.js
@@ -74,25 +74,26 @@
       enabled: true,
       configFile: `${themeDir}pattern-lab/config/config.yml`,
       watchedExtensions: (['twig', 'json', 'yaml', 'yml', 'md', 'jpg', 'jpeg', 'png']),
-      scssToJson: [
+      scssToYAML: [
         {
           src: `${themeDir}/components/_patterns/00-base/global/01-colors/_color-vars.scss`,
-          dest: `${themeDir}/components/_patterns/00-base/global/01-colors/colors.json`,
+          dest: `${themeDir}/components/_patterns/00-base/global/01-colors/colors.yml`,
           lineStartsWith: '$',
           allowVarValues: false
         }
       ]
     },
     browserSync: {
+      ui: false,
       enabled: true,
       baseDir: './',
-      startPath: `pattern-lab/public/`,
+      startPath: `${themeDir}pattern-lab/public/`,
       // Uncomment below if using a specific local url
       // domain: 'emulsify.dev',
-      notify: false,
-      openBrowserAtStart: false,
-      reloadOnRestart: true,
-      ui: false,
+      openBrowserAtStart: true,
+      browser: "google chrome",
+      reloadDelay: 50,
+      reloadDebounce: 750
     },
     wpt: {
       // WebPageTest API key https://www.webpagetest.org/getkey.php

--- a/gulp-config.js
+++ b/gulp-config.js
@@ -84,16 +84,15 @@
       ]
     },
     browserSync: {
-      ui: false,
       enabled: true,
       baseDir: './',
-      startPath: `${themeDir}pattern-lab/public/`,
+      startPath: `pattern-lab/public/`,
       // Uncomment below if using a specific local url
       // domain: 'emulsify.dev',
-      openBrowserAtStart: true,
-      browser: "google chrome",
-      reloadDelay: 50,
-      reloadDebounce: 750
+      notify: false,
+      openBrowserAtStart: false,
+      reloadOnRestart: true,
+      ui: false,
     },
     wpt: {
       // WebPageTest API key https://www.webpagetest.org/getkey.php

--- a/gulp-tasks/gulp-pattern-lab.js
+++ b/gulp-tasks/gulp-pattern-lab.js
@@ -51,12 +51,12 @@
 
     const plFullDependencies = [];
 
-    if (config.patternLab.scssToJson) {
-      // turns scss files full of variables into json files that PL can iterate on
-      gulp.task('pl:scss-to-json', done => {
-        config.patternLab.scssToJson.forEach(({src, lineStartsWith, allowVarValues, dest}) => {
+    if (config.patternLab.scssToYAML) {
+      // turns scss files full of variables into yaml files that PL can iterate on
+      gulp.task('pl:scss-to-yaml', done => {
+        config.patternLab.scssToYAML.forEach(({src, lineStartsWith, allowVarValues, dest}) => {
           let scssVarList = _.filter(fs.readFileSync(src, 'utf8').split('\n'), item => _.startsWith(item, lineStartsWith));
-          // console.log(scssVarList, item.src);
+
           let varsAndValues = _.map(scssVarList, item => {
             let x = item.split(':');
             return {
@@ -69,23 +69,23 @@
             varsAndValues = _.filter(varsAndValues, ({value}) => !_.startsWith(value, '$'));
           }
 
-          fs.writeFileSync(dest, JSON.stringify({
+          fs.writeFileSync(dest, yaml.dump({
             items: varsAndValues,
             meta: {
               description: `To add to these items, use Sass variables that start with <code>${lineStartsWith}</code> in <code>${src}</code>`
             }
-          }, null, '  '));
+          }));
 
         });
         done();
       });
-      plFullDependencies.push('pl:scss-to-json');
+      plFullDependencies.push('pl:scss-to-yaml');
 
-      gulp.task('watch:pl:scss-to-json', () => {
-        const files = config.patternLab.scssToJson.map(({src}) => src);
-        gulp.watch(files, ['pl:scss-to-json']);
+      gulp.task('watch:pl:scss-to-yaml', () => {
+        const files = config.patternLab.scssToYAML.map(({src}) => src);
+        gulp.watch(files, ['pl:scss-to-yaml']);
       });
-      watch.push('watch:pl:scss-to-json');
+      watch.push('watch:pl:scss-to-yaml');
     }
 
     gulp.task('pl:full', false, plFullDependencies, plBuild);

--- a/index.js
+++ b/index.js
@@ -120,6 +120,7 @@ module.exports = (gulp, config) => {
     gulp.watch(config.paths.js, ['scripts']).on('change', browserSync.reload);
     gulp.watch(config.paths.styleguide_js, ['styleguide-scripts']).on('change', browserSync.reload);
     gulp.watch(`${config.paths.sass}/**/*.scss`, ['css']);
+    gulp.watch(config.patternLab.scssToYAML[0].src, ['pl:scss-to-yaml']);
   });
 
   /**


### PR DESCRIPTION
This PR converts color.json to color.yml, because YAML is better. 👍 

## How to review
- [x] Download this branch
- [ ] Download a fresh of the core Emulsify project
  - [ ] Remove Emulsify Gulp from package.json
  - [ ] Delete `components/_patterns/00-base/global/01-colors/colors.json`
  - [ ] `yarn add file:../path/to/emulsify-gulp`
- [ ] Run `yarn start`
- [ ] See that the colors are correct in Pattern Lab
- [ ] Confirm that there is `components/_patterns/00-base/global/01-colors/colors.yml` (and no .json file)