### PR TITLE
HOTFIX: Add min node version of 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emulsify-gulp",
   "description": "A collection of useful gulp tasks.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "lint": "eslint --ext .js .",
     "precommit": "npm run lint"
@@ -49,5 +49,8 @@
     "eslint-config-airbnb-base": "^11.3.1",
     "eslint-plugin-import": "^2.7.0"
   },
-  "pre-commit": "lint"
+  "pre-commit": "lint",
+  "engines" : {
+    "node" : ">=6" 
+  }
 }


### PR DESCRIPTION
With the conversion to ES6 we have to set a minimum version of Node to 6.

## How to review
- [x] Install a clean copy of Emulsify
- [x] `yarn remove emulsify-gulp`
- [x] `nvm use 5`
- [x] `yarn add file:../path/to/local/emulsify-gulp`
  -[ ] Get error `The engine "node" is incompatible with this module. Expected version ">=6".`
- [x] `nvm use 6`
- [x] `yarn add file:../path/to/local/emulsify-gulp`
  - [x]  Successfully installs

## After merge, do a minor release.