### PR TITLE
change code back to pre-ES6 for gh-pages-deploy

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,8 +142,9 @@ module.exports = (gulp, config) => {
   /**
    * Deploy
    */
-  gulp.task('ghpages-deploy', () => {
-    gulp.src([
+  // eslint-disable-next-line func-names, prefer-arrow-callback
+  gulp.task('ghpages-deploy', function () {
+    return gulp.src([
       `${config.paths.dist_js}/**/*`,
       `${config.paths.pattern_lab}/**/*`,
     ], { base: config.themeDir })


### PR DESCRIPTION
Fixes https://github.com/fourkitchens/emulsify-gulp/issues/59

Changing to the arrow callback method on this function caused it to not work. I changed it back to the old syntax with eslint commenting, but obviously if you know a way to make it work with the ES6 syntax that's fine too. 