### PR TITLE
Install Babel Minify, add to presets

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = (gulp, config) => {
     gulp.src(config.paths.js)
       .pipe(sourcemaps.init())
       .pipe(babel({
-        presets: ['env'],
+        presets: ['env', 'minify'],
       }))
       .pipe(sourcemaps.write(config.themeDir))
       .pipe(gulp.dest(config.paths.dist_js));

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "babel-core": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "babel-preset-minify": "^0.2.0",
     "breakpoint-sass": "^2.7.0",
     "browser-sync": "^2.11.0",
     "del": "^3.0.0",


### PR DESCRIPTION
Adds JS minification using https://github.com/babel/minify. Solves https://github.com/fourkitchens/emulsify-gulp/issues/63

**To test:**

- [x] Clone a fresh copy of [Emulsify](https://github.com/fourkitchens/emulsify)
- [x] `composer install`
- [x] Change line 6 in package.json to `"emulsify-gulp": "fourkitchens/emulsify-gulp#babel-minify",`
- [x] `yarn install`
- [x] `yarn start`
- [x] Verify start command runs without errors
- [x] Verify [Pattern Lab components with JavaScript work OK](http://localhost:3000/pattern-lab/public/?p=viewall-molecules-accordion-item)
- [x] Verify dist JS is minified. The file here `dist/02-molecules/menus/main-menu/main-menu.js` should look like code below:

```
'use strict';(function(){'use strict';var a=document.getElementById('toggle-expand'),b=document.getElementById('main-nav'),c=b.getElementsByClassName('expand-sub');console.log(a),a.addEventListener('click',function(){a.classList.toggle('toggle-expand--open'),b.classList.toggle('main-nav--open')});for(var d=0;d<c.length;d++)c[d].addEventListener('click',function(a){var b=a.currentTarget,c=b.nextElementSibling;b.classList.toggle('expand-sub--open'),c.classList.toggle('main-menu--sub-open')})})();
//# sourceMappingURL=main-menu.js.map
```