### PR TITLE
Switch SVG sprite to use symbol mode

### DIFF
--- a/gulp-config.js
+++ b/gulp-config.js
@@ -41,28 +41,17 @@
       includePaths: (['./node_modules']),
     },
     iconConfig: {
-      shape: {
-        dimension: {
-          maxWidth: 15,
-          maxHeight: 15,
-        },
-        spacing: {
-          padding: 10,
-        },
-      },
       mode: {
-        css: {
-          bust: false,
-          dest: '../../dist',
-          prefix: '@mixin sprite-%s',
-          render: {
-            scss: {
-              dest: '../components/_patterns/01-atoms/04-images/icons/_icon_sprite.scss',
-              template: 'node_modules/emulsify-gulp/gulp-tasks/svg-icons/sprite.scss.handlebars',
-            },
-          },
-        },
+        symbol: { // symbol mode to build the SVG
+          dest: 'dist/img/sprite', // destination foldeer
+          sprite: 'sprite.svg', // sprite name
+          example: false // Don't build sample page
+        }
       },
+      svg: {
+        xmlDeclaration: false, // strip out the XML attribute
+        doctypeDeclaration: false // don't include the !DOCTYPE declaration
+      }
     },
     patternLab: {
       enabled: true,

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = (gulp, config) => {
   gulp.task('icons', () => {
     gulp.src('**/*.svg', { cwd: `${config.paths.img}/icons/src` })
       .pipe(svgSprite(config.iconConfig))
-      .pipe(gulp.dest(`${config.themeDir}/images/icons`));
+      .pipe(gulp.dest('.'));
   });
 
   tasks.compile.push('icons');


### PR DESCRIPTION
**Note: This and [the matching Emulsify PR](https://github.com/fourkitchens/emulsify/pull/206) should be merged/released simultaneously**

Switches SVG sprite settings to use symbol mode (away from CSS mode). Fixes https://github.com/fourkitchens/emulsify-gulp/issues/68