### PR TITLE
Imagemin Updates

### DIFF
--- a/gulp-config.js
+++ b/gulp-config.js
@@ -8,11 +8,9 @@
     sass: themeDir,
     img: [
       `${themeDir}/images/**/*`,
-      `!${themeDir}/images/icons/**/*`,
-      `!${themeDir}/images/icons/`,
+      `${themeDir}/components/_patterns/**/*.{jpg, gif, png, svg}`,
     ],
     dist_css: `${themeDir}/dist/css`,
-    dist_img: `${themeDir}/images`,
     pattern_lab: `${themeDir}/pattern-lab/public`,
   };
 

--- a/gulp-config.js
+++ b/gulp-config.js
@@ -6,9 +6,13 @@
     js: `${themeDir}/components/_patterns/**/*.js`,
     dist_js: `${themeDir}/dist`,
     sass: themeDir,
-    img: `${themeDir}/images`,
+    img: [
+      `${themeDir}/images/**/*`,
+      `!${themeDir}/images/icons/**/*`,
+      `!${themeDir}/images/icons/`,
+    ],
     dist_css: `${themeDir}/dist/css`,
-    dist_img: `${themeDir}/dist/img`,
+    dist_img: `${themeDir}/images`,
     pattern_lab: `${themeDir}/pattern-lab/public`,
   };
 
@@ -45,13 +49,13 @@
         symbol: { // symbol mode to build the SVG
           dest: 'dist/img/sprite', // destination foldeer
           sprite: 'sprite.svg', // sprite name
-          example: false // Don't build sample page
-        }
+          example: false, // Don't build sample page
+        },
       },
       svg: {
         xmlDeclaration: false, // strip out the XML attribute
-        doctypeDeclaration: false // don't include the !DOCTYPE declaration
-      }
+        doctypeDeclaration: false, // don't include the !DOCTYPE declaration
+      },
     },
     patternLab: {
       enabled: true,

--- a/index.js
+++ b/index.js
@@ -69,14 +69,16 @@ module.exports = (gulp, config) => {
    * Task for minifying images.
    */
   gulp.task('imagemin', () => {
-    gulp.src(`${config.paths.img}/**/*`)
-      .pipe(imagemin({
-        progressive: true,
-        svgoPlugins: [
-          { removeViewBox: false },
-          { cleanupIDs: false },
-        ],
-      }))
+    gulp
+      .src(config.paths.img)
+      .pipe(
+        imagemin([
+          imagemin.jpegtran({ progressive: true }),
+          imagemin.svgo({
+            plugins: [{ removeViewBox: false }, { cleanupIDs: false }],
+          }),
+        ]),
+      )
       .pipe(gulp.dest(config.paths.dist_img));
   });
 
@@ -103,7 +105,7 @@ module.exports = (gulp, config) => {
   /**
    * Task for running browserSync.
    */
-  gulp.task('serve', ['css', 'scripts', 'styleguide-scripts', 'watch:pl'], () => {
+  gulp.task('serve', ['css', 'scripts', 'styleguide-scripts', 'imagemin', 'watch:pl'], () => {
     if (config.browserSync.domain) {
       browserSync.init({
         injectChanges: true,
@@ -127,6 +129,7 @@ module.exports = (gulp, config) => {
     }
     gulp.watch(config.paths.js, ['scripts', 'styleguide-scripts']).on('change', browserSync.reload);
     gulp.watch(`${config.paths.sass}/**/*.scss`, ['css']);
+    gulp.watch(config.paths.img, ['imagemin']);
     gulp.watch(config.patternLab.scssToYAML[0].src, ['pl:scss-to-yaml']);
   });
 

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ module.exports = (gulp, config) => {
           }),
         ]),
       )
-      .pipe(gulp.dest(config.paths.dist_img));
+      .pipe(gulp.dest(file => file.base));
   });
 
   /**
@@ -105,7 +105,7 @@ module.exports = (gulp, config) => {
   /**
    * Task for running browserSync.
    */
-  gulp.task('serve', ['css', 'scripts', 'styleguide-scripts', 'imagemin', 'watch:pl'], () => {
+  gulp.task('serve', ['imagemin', 'css', 'scripts', 'styleguide-scripts', 'watch:pl'], () => {
     if (config.browserSync.domain) {
       browserSync.init({
         injectChanges: true,


### PR DESCRIPTION
References https://github.com/fourkitchens/emulsify-gulp/issues/69

The PR does the following:
1. Fixes syntax for gulp-imagemin >3
2. Minifies everything including SVGs
3. Overwrites current files (anywhere in `/images` **and** `/components/_patterns` instead of using `dist` directory (don't need original images which means the task will run faster over time). 
4. Adds imagemin task to `yarn start` and also watches for changes.

**How to test:**
- [x] Clone a fresh copy of Emulsify and change the emulsify-gulp devDependency in package.json to `fourkitchens/emulsify-gulp#better-imagemin`
- [x] Run `composer install` and then `yarn install`
- [x] Add some images to the repo either in `/images` or `/components/_patterns/WHEREVER` in whatever format (svg, png, gif, jpg)
- [x] Run `yarn start` and verify those images are optimized in place.
- [x] Add some more images in either of those directories and run `gulp imagemin` and verify those are minified.