### PR TITLE
65: Remove styleguide-scripts Gulp task and any references, deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,6 @@ module.exports = (gulp, config) => {
   // eslint-disable-next-line no-redeclare, no-var
   var config = _.defaultsDeep(config, defaultConfig);
 
-  // scripts
-  const concat = require('gulp-concat');
-
   // Image Minification
   const imagemin = require('gulp-imagemin');
 
@@ -52,21 +49,6 @@ module.exports = (gulp, config) => {
           presets: ['env', 'minify'],
         }),
       )
-      .pipe(sourcemaps.write(config.themeDir))
-      .pipe(gulp.dest(config.paths.dist_js));
-  });
-
-  gulp.task('styleguide-scripts', () => {
-    gulp
-      .src(config.paths.js)
-      .pipe(sourcemaps.init())
-      .pipe(
-        babel({
-          presets: ['env'],
-        }),
-      )
-      // Concatenate everything within the JavaScript folder.
-      .pipe(concat('scripts-styleguide.js'))
       .pipe(sourcemaps.write(config.themeDir))
       .pipe(gulp.dest(config.paths.dist_js));
   });
@@ -112,7 +94,7 @@ module.exports = (gulp, config) => {
   /**
    * Task for running browserSync.
    */
-  gulp.task('serve', ['imagemin', 'css', 'scripts', 'styleguide-scripts', 'watch:pl'], () => {
+  gulp.task('serve', ['imagemin', 'css', 'scripts', 'watch:pl'], () => {
     if (config.browserSync.domain) {
       browserSync.init({
         injectChanges: true,
@@ -134,7 +116,7 @@ module.exports = (gulp, config) => {
         port: openPort,
       });
     }
-    gulp.watch(config.paths.js, ['scripts', 'styleguide-scripts']).on('change', browserSync.reload);
+    gulp.watch(config.paths.js, ['scripts']).on('change', browserSync.reload);
     gulp.watch(`${config.paths.sass}/**/*.scss`, ['css']);
     gulp.watch(config.paths.img, ['imagemin']);
     gulp.watch(config.patternLab.scssToYAML[0].src, ['pl:scss-to-yaml']);
@@ -155,7 +137,7 @@ module.exports = (gulp, config) => {
   /**
    * Theme task declaration
    */
-  gulp.task('build', ['imagemin', 'clean', 'scripts', 'styleguide-scripts', 'css', 'icons']);
+  gulp.task('build', ['imagemin', 'clean', 'scripts', 'css', 'icons']);
 
   /**
    * Deploy


### PR DESCRIPTION
Companion to https://github.com/fourkitchens/emulsify/pull/245, this PR removes this now unnecessary task as well as any references, deps. Follow testing instructions on that PR to test this and make sure you are using this branch of emulsify-gulp in your testing. 