### PR TITLE
remove trailing commas from function calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = (gulp, config) => {
       .pipe(
         babel({
           presets: ['env', 'minify'],
-        }),
+        })
       )
       .pipe(sourcemaps.write(config.themeDir))
       .pipe(gulp.dest(config.paths.dist_js));
@@ -63,7 +63,7 @@ module.exports = (gulp, config) => {
       .pipe(
         babel({
           presets: ['env'],
-        }),
+        })
       )
       // Concatenate everything within the JavaScript folder.
       .pipe(concat('scripts-styleguide.js'))
@@ -83,7 +83,7 @@ module.exports = (gulp, config) => {
           imagemin.svgo({
             plugins: [{ removeViewBox: false }, { cleanupIDs: false }],
           }),
-        ]),
+        ])
       )
       .pipe(gulp.dest(file => file.base));
   });
@@ -169,7 +169,7 @@ module.exports = (gulp, config) => {
           `${config.paths.pattern_lab}/**/*`,
           `${config.themeDir}/CNAME`,
         ],
-        { base: config.themeDir },
+        { base: config.themeDir }
       )
       .pipe(gulp.dest('build'));
     // Publish the build directory to github pages.


### PR DESCRIPTION
Trailing commas in function syntax [weren't supported until Node 8](https://node.green/#ES2017-features-trailing-commas-in-function-syntax), so this is breaking projects using older versions.

This removes trailing commas from the function calls in index.js.
