### PR TITLE
82: Remove imagemin watch task, remove clean task

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,4 @@
 extends: airbnb-base
 rules:
   global-require: off
+  comma-dangle: 0

--- a/gulp-tasks/gulp-css.js
+++ b/gulp-tasks/gulp-css.js
@@ -8,10 +8,9 @@ const cached = require('gulp-cached');
 const flatten = require('gulp-flatten');
 const gulpif = require('gulp-if');
 const cleanCSS = require('gulp-clean-css');
-const del = require('del');
 
 ((() => {
-  module.exports = (gulp, { cssConfig, debug }, { watch, validate, clean }, browserSync) => {
+  module.exports = (gulp, { cssConfig, debug }, { watch, validate }, browserSync) => {
     function cssCompile(done) {
       gulp.src(cssConfig.src)
         .pipe(sassGlob())
@@ -41,14 +40,6 @@ const del = require('del');
     }
 
     gulp.task('css', 'Compile Scss to CSS using Libsass with Autoprefixer and SourceMaps', cssCompile);
-
-    gulp.task('clean:css', 'Delete compiled CSS files', (done) => {
-      del([
-        `${cssConfig.dest}*.{css,css.map}`,
-      ]).then(() => {
-        done();
-      });
-    });
 
     gulp.task('validate:css', 'Lint Scss files', () => {
       let src = cssConfig.src;
@@ -81,7 +72,5 @@ const del = require('del');
     if (cssConfig.lint.enabled) {
       validate.push('validate:css');
     }
-
-    clean.push('clean:css');
   };
 }))();

--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ module.exports = (gulp, config) => {
     compile: [],
     watch: [],
     validate: [],
-    clean: [],
     default: [],
   };
 
@@ -147,7 +146,6 @@ module.exports = (gulp, config) => {
   gulp.task('theme', ['serve']);
 
   gulp.task('compile', tasks.compile);
-  gulp.task('clean', tasks.clean);
   gulp.task('validate', tasks.validate);
   gulp.task('watch', tasks.watch);
   tasks.default.push('watch');
@@ -156,7 +154,7 @@ module.exports = (gulp, config) => {
   /**
    * Theme task declaration
    */
-  gulp.task('build', ['imagemin', 'clean', 'scripts', 'styleguide-scripts', 'css', 'icons']);
+  gulp.task('build', ['imagemin', 'scripts', 'styleguide-scripts', 'css', 'icons']);
 
   /**
    * Deploy

--- a/index.js
+++ b/index.js
@@ -88,6 +88,8 @@ module.exports = (gulp, config) => {
       .pipe(gulp.dest(file => file.base));
   });
 
+  tasks.compile.push('imagemin');
+
   /**
    * Task for generating icon colors/png fallbacks from svg.
    */
@@ -112,7 +114,7 @@ module.exports = (gulp, config) => {
   /**
    * Task for running browserSync.
    */
-  gulp.task('serve', ['imagemin', 'css', 'scripts', 'styleguide-scripts', 'watch:pl'], () => {
+  gulp.task('serve', ['css', 'scripts', 'styleguide-scripts', 'watch:pl'], () => {
     if (config.browserSync.domain) {
       browserSync.init({
         injectChanges: true,
@@ -136,7 +138,6 @@ module.exports = (gulp, config) => {
     }
     gulp.watch(config.paths.js, ['scripts', 'styleguide-scripts']).on('change', browserSync.reload);
     gulp.watch(`${config.paths.sass}/**/*.scss`, ['css']);
-    gulp.watch(config.paths.img, ['imagemin']);
     gulp.watch(config.patternLab.scssToYAML[0].src, ['pl:scss-to-yaml']);
   });
 


### PR DESCRIPTION
Attempt to fix https://github.com/fourkitchens/emulsify-gulp/issues/82

- Removes imagemin watch task (and duplicate serve task). Image minification will now only take place when running yarn start instead of when saving images. This wasn't extremely helpful to begin with since new images being added didn't trigger the watch task anyway.
- Removes cruft clean task (See [accompanying Emulsify issue](https://github.com/fourkitchens/emulsify/pull/280)) that was not performing any useful tasks

To Test:
- [ ] Use this branch of Emulsify gulp and test against [the Emulsify branch](https://github.com/fourkitchens/emulsify/pull/280). 