### PR TITLE
 Updating browsersync config “domain” to use proxy and host 

### DIFF
--- a/gulp-config.js
+++ b/gulp-config.js
@@ -71,8 +71,9 @@
       enabled: true,
       baseDir: './',
       startPath: 'pattern-lab/public/',
-      // Uncomment below if using a specific local url
-      // domain: 'emulsify.dev',
+      // Uncomment proxy and host below if using a specific local url.
+      // proxy: 'mysite.dev',
+      // host: 'mysite.dev',
       notify: false,
       openBrowserAtStart: false,
       reloadOnRestart: true,

--- a/index.js
+++ b/index.js
@@ -96,12 +96,16 @@ module.exports = (gulp, config) => {
    * Task for running browserSync.
    */
   gulp.task('serve', ['css', 'scripts', 'watch:pl'], () => {
-    if (config.browserSync.domain) {
+    if (config.browserSync.proxy && config.browserSync.host) {
+      console.log('Using proxy and host!')
       browserSync.init({
         injectChanges: true,
         open: config.browserSync.openBrowserAtStart,
-        proxy: config.browserSync.domain,
+        proxy: config.browserSync.proxy,
+        host: config.browserSync.host,
         startPath: config.browserSync.startPath,
+        notify: config.browserSync.notify,
+        baseDir: config.browserSync.baseDir,
       });
     } else {
       browserSync.init({


### PR DESCRIPTION
Even though `config.browserSync.domain,` was mapped to proxy, It might be confusing to use "domain" as a local browserSync setting as there is actually a real setting for domain in browserSync. I also discovered that it works best if `host` is used in tandem with `proxy`. 

However, this could be an edge case. I'm using Docksal so it was crucial for host and proxy to be used together for browserSync to work on the Docksal domain. Note the browserSync setting for "domain" (AKA `socket`) actually has to do with using in tandem for `socket.io`. https://browsersync.io/docs/options#option-socket

I also added in some more standard options that are nice to have within the proxy if statement which I also updated to check for the two conditions needed. 

If this pull request is not acceptable, I'm fine with just running a patch automatically after npm install. 