### PR TITLE
91 Add theme images directory and theme logo to GitHub pages deployment

### DIFF
--- a/gulp-config.js
+++ b/gulp-config.js
@@ -13,6 +13,8 @@
     ],
     dist_css: `${themeDir}/dist/css`,
     pattern_lab: `${themeDir}/pattern-lab/public`,
+    theme_images: `${themeDir}/images`,
+    logo: `${themeDir}/logo.png`,
   };
 
   module.exports = {

--- a/index.js
+++ b/index.js
@@ -148,6 +148,9 @@ module.exports = (gulp, config) => {
         [
           `${config.paths.dist_js}/**/*`,
           `${config.paths.pattern_lab}/**/*`,
+          `${config.paths.theme_images}/**/*`,
+          `!${config.paths.theme_images}/{icons,icons/**/*}`,
+          `${config.paths.logo}`,
           `${config.themeDir}/CNAME`,
         ],
         { base: config.themeDir }


### PR DESCRIPTION
#91 Add theme images directory without the icons folder (as that is just a source for the generated icons sprite).

Also add the theme's logo file. (Unfortunately just the png version currently as `logo.{svg, jpg, png}` did not work.)