### PR TITLE
Added pa11y, set up testing for twig, scss reloading

### DIFF
--- a/gulp-config.js
+++ b/gulp-config.js
@@ -82,5 +82,14 @@
       // WebPageTest API key https://www.webpagetest.org/getkey.php
       // key:
     },
+    pa11y: {
+      includeNotices: false,
+      includeWarnings: true,
+      ignore: [
+        'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
+        'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.1.NoTitleEl',
+        'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
+      ]
+    },
   };
 })();

--- a/gulp-config.js
+++ b/gulp-config.js
@@ -83,13 +83,20 @@
       // key:
     },
     pa11y: {
-      includeNotices: false,
+      includeNotices: true,
       includeWarnings: true,
       ignore: [
         'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
         'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.1.NoTitleEl',
         'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
-      ]
+        'WCAG2AA.Principle3.Guideline3_2.3_2_1.G107',
+      ],
+      hideElements: '',
+      rootElement: null,
+      rules: [],
+      standard: 'WCAG2AA',
+      wait: 250,
+      actions: [],
     },
   };
 })();

--- a/gulp-tasks/gulp-pattern-lab.js
+++ b/gulp-tasks/gulp-pattern-lab.js
@@ -4,6 +4,9 @@ const notifier = require('./notifier.js');
 const path = require('path');
 const yaml = require('js-yaml');
 const fs = require('fs');
+const pa11y = require('pa11y');
+// eslint-disable-next-line
+const pa11yCli = require('pa11y-reporter-cli');
 
 ((() => {
   module.exports = (gulp, config, { watch, compile }, browserSync) => {
@@ -35,6 +38,28 @@ const fs = require('fs');
         notifier.sh(`php ${consolePath} --generate`, false, () => {
           if (config.browserSync.enabled) {
             browserSync.reload('*.html');
+          }
+        });
+        // Accessibility.
+        const localUrl = browserSync.getOption('urls').get('local');
+        const filePath = event.path;
+        const pLPath = filePath.split('_patterns/').pop();
+        const filetoArray = pLPath.split('/');
+        const arraytoPath = filetoArray.join('-');
+        const arraytoPathTweak = arraytoPath.slice(0, -5);
+        const pa11yUrl = `${localUrl}patterns/${arraytoPathTweak}/${arraytoPathTweak}.html`;
+        pa11y(pa11yUrl, {
+          includeWarnings: true,
+          ignore: [
+            'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
+            'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.1.NoTitleEl',
+            'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
+          ]
+        }).then((results) => {
+          if (results.issues === undefined || results.issues.length < 1) {
+            console.log('[pa11y] No accessibility issues found!');
+          } else {
+            console.log(pa11yCli.results(results));
           }
         });
       });

--- a/gulp-tasks/gulp-pattern-lab.js
+++ b/gulp-tasks/gulp-pattern-lab.js
@@ -4,9 +4,7 @@ const notifier = require('./notifier.js');
 const path = require('path');
 const yaml = require('js-yaml');
 const fs = require('fs');
-const pa11y = require('pa11y');
-// eslint-disable-next-line
-const pa11yCli = require('pa11y-reporter-cli');
+const pa11y = require('./pa11y');
 
 ((() => {
   module.exports = (gulp, config, { watch, compile }, browserSync) => {
@@ -41,27 +39,7 @@ const pa11yCli = require('pa11y-reporter-cli');
           }
         });
         // Accessibility.
-        const localUrl = browserSync.getOption('urls').get('local');
-        const filePath = event.path;
-        const pLPath = filePath.split('_patterns/').pop();
-        const filetoArray = pLPath.split('/');
-        const arraytoPath = filetoArray.join('-');
-        const arraytoPathTweak = arraytoPath.slice(0, -5);
-        const pa11yUrl = `${localUrl}patterns/${arraytoPathTweak}/${arraytoPathTweak}.html`;
-        pa11y(pa11yUrl, {
-          includeWarnings: true,
-          ignore: [
-            'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
-            'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.1.NoTitleEl',
-            'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
-          ]
-        }).then((results) => {
-          if (results.issues === undefined || results.issues.length < 1) {
-            console.log('[pa11y] No accessibility issues found!');
-          } else {
-            console.log(pa11yCli.results(results));
-          }
-        });
+        pa11y.pa11yTest(event.path, browserSync, config);
       });
     });
 

--- a/gulp-tasks/pa11y.js
+++ b/gulp-tasks/pa11y.js
@@ -64,13 +64,14 @@ function pa11yTest(path, browserSync, config) {
 
     fs.readdir(fileDir, (err, items) => {
       items.forEach((item) => {
-        if (item.split('.').pop() === 'twig' && item.charAt(0) !== '_') {
+        // Select components based on YAML files.
+        if (item.split('.').pop() === 'yml') {
           // Change array to string separated by dash.
           const twigFilePath = `${fileDir}/${item}`;
           const twigFilePlPath = twigFilePath.split('_patterns/').pop();
           const filetoArray = twigFilePlPath.split('/');
           const arraytoPath = filetoArray.join('-');
-          const arraytoPathTweak = arraytoPath.slice(0, -5);
+          const arraytoPathTweak = arraytoPath.replace('~', '-').slice(0, -4);
           const pa11yPath = `${localUrl}patterns/${arraytoPathTweak}/${arraytoPathTweak}.html`;
           pa11yRun(pa11yPath, config);
         }

--- a/gulp-tasks/pa11y.js
+++ b/gulp-tasks/pa11y.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const pa11y = require('pa11y');
+// eslint-disable-next-line
+const pa11yCli = require('pa11y-reporter-cli');
+
+function pa11yRun(pa11yUrl, config) {
+  pa11y(pa11yUrl, {
+    includeNotices: config.pa11y.includeNotices,
+    includeWarnings: config.pa11y.includeWarnings,
+    ignore: config.pa11y.ignore
+  }).then((results) => {
+    if (results.issues === undefined || results.issues.length < 1) {
+      console.log('[pa11y] No accessibility issues found!');
+    } else {
+      console.log(pa11yCli.results(results));
+    }
+  });
+}
+
+/**
+ * Accessibility Testing
+ */
+
+// Accessibility testing via pa11y.
+function pa11yTest(path, browserSync, config) {
+  // Get local url.
+  const localUrl = browserSync.getOption('urls').get('local');
+  const filePath = path;
+  // Get remaining path after ../_patterns/.
+  const pLPath = filePath.split('_patterns/').pop();
+  // Change remaining path string to array.
+  const fileArray = pLPath.split('/');
+  // Remove filename (just want directory).
+  fileArray.splice(-1, 1);
+
+  // CSS returns a couple of paths and causes duplication.
+  if (filePath.split('/').includes('pattern-lab')) {
+    const fileDir = `${filePath.split('_patterns/')[0]}_patterns/${fileArray.join('/')}`;
+
+    fs.readdir(fileDir, (err, items) => {
+      items.forEach((item) => {
+        if (item.split('.').pop() === 'twig') {
+          // Change array to string separated by dash.
+          const twigFilePath = `${fileDir}/${item}`;
+          const twigFilePlPath = twigFilePath.split('_patterns/').pop();
+          const filetoArray = twigFilePlPath.split('/');
+          const arraytoPath = filetoArray.join('-');
+          const arraytoPathTweak = arraytoPath.slice(0, -5);
+          const pa11yPath = `${localUrl}patterns/${arraytoPathTweak}/${arraytoPathTweak}.html`;
+          console.log(`Running accessibility tests on ${pa11yPath}`);
+          pa11yRun(pa11yPath, config);
+        }
+      });
+    });
+  }
+}
+
+module.exports.pa11yTest = pa11yTest;

--- a/gulp-tasks/pa11y.js
+++ b/gulp-tasks/pa11y.js
@@ -3,10 +3,6 @@ const pa11y = require('pa11y');
 // eslint-disable-next-line
 const pa11yCli = require('pa11y-reporter-cli');
 
-// function pa11yRun(pa11yUrl, config) {
-//
-// }
-
 async function pa11yRun(pa11yUrl, config) {
   try {
     await pa11y(pa11yUrl, {

--- a/gulp-tasks/pa11y.js
+++ b/gulp-tasks/pa11y.js
@@ -3,18 +3,28 @@ const pa11y = require('pa11y');
 // eslint-disable-next-line
 const pa11yCli = require('pa11y-reporter-cli');
 
-function pa11yRun(pa11yUrl, config) {
-  pa11y(pa11yUrl, {
-    includeNotices: config.pa11y.includeNotices,
-    includeWarnings: config.pa11y.includeWarnings,
-    ignore: config.pa11y.ignore
-  }).then((results) => {
-    if (results.issues === undefined || results.issues.length < 1) {
-      console.log('[pa11y] No accessibility issues found!');
-    } else {
-      console.log(pa11yCli.results(results));
-    }
-  });
+// function pa11yRun(pa11yUrl, config) {
+//
+// }
+
+async function pa11yRun(pa11yUrl, config) {
+  try {
+    await pa11y(pa11yUrl, {
+      includeNotices: config.pa11y.includeNotices,
+      includeWarnings: config.pa11y.includeWarnings,
+      ignore: config.pa11y.ignore
+    }).then((results) => {
+      if (results.issues === undefined || results.issues.length < 1) {
+        console.log('[pa11y] No accessibility issues found!');
+      } else {
+        console.log(pa11yCli.results(results));
+      }
+    });
+    // Do something with the results
+  } catch (error) {
+    // Handle the error
+    console.log(error);
+  }
 }
 
 /**
@@ -39,7 +49,7 @@ function pa11yTest(path, browserSync, config) {
 
     fs.readdir(fileDir, (err, items) => {
       items.forEach((item) => {
-        if (item.split('.').pop() === 'twig') {
+        if (item.split('.').pop() === 'twig' && item.charAt(0) !== '_') {
           // Change array to string separated by dash.
           const twigFilePath = `${fileDir}/${item}`;
           const twigFilePlPath = twigFilePath.split('_patterns/').pop();
@@ -47,7 +57,6 @@ function pa11yTest(path, browserSync, config) {
           const arraytoPath = filetoArray.join('-');
           const arraytoPathTweak = arraytoPath.slice(0, -5);
           const pa11yPath = `${localUrl}patterns/${arraytoPathTweak}/${arraytoPathTweak}.html`;
-          console.log(`Running accessibility tests on ${pa11yPath}`);
           pa11yRun(pa11yPath, config);
         }
       });

--- a/gulp-tasks/pa11y.js
+++ b/gulp-tasks/pa11y.js
@@ -12,7 +12,13 @@ async function pa11yRun(pa11yUrl, config) {
     await pa11y(pa11yUrl, {
       includeNotices: config.pa11y.includeNotices,
       includeWarnings: config.pa11y.includeWarnings,
-      ignore: config.pa11y.ignore
+      ignore: config.pa11y.ignore,
+      hideElements: config.pa11y.hideElements,
+      rootElement: config.pa11y.rootElement,
+      rules: config.pa11y.rules,
+      standard: config.pa11y.standard,
+      wait: config.pa11y.wait,
+      actions: config.pa11y.actions,
     }).then((results) => {
       if (results.issues === undefined || results.issues.length < 1) {
         console.log('[pa11y] No accessibility issues found!');

--- a/gulp-tasks/pa11y.js
+++ b/gulp-tasks/pa11y.js
@@ -24,6 +24,15 @@ async function pa11yRun(pa11yUrl, config) {
         console.log('[pa11y] No accessibility issues found!');
       } else {
         console.log(pa11yCli.results(results));
+        if (config.pa11y.includeNotices === true) {
+          console.log('Note: pa11y notices are enabled by default. To disable notices, edit local.gulp-config.js and set "includeNotices" to false.');
+        }
+        if (config.pa11y.includeWarnings === true) {
+          console.log('Note: pa11y warnings are enabled by default. To disable warnings, edit local.gulp-config.js and set "includeWarnings" to false.');
+        }
+        if (config.pa11y.includeNotices === true || config.pa11y.includeWarnings === true) {
+          console.log('See https://github.com/fourkitchens/emulsify/wiki/Gulp-Config for details.');
+        }
       }
     });
     // Do something with the results

--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ module.exports = (gulp, config) => {
   const babel = require('gulp-babel');
   const sourcemaps = require('gulp-sourcemaps');
   const defaultConfig = require('./gulp-config');
+  const fs = require('fs');
+  const pa11y = require('pa11y');
+  // eslint-disable-next-line
+  const pa11yCli = require('pa11y-reporter-cli');
 
   // eslint-disable-next-line no-redeclare, no-var
   var config = _.defaultsDeep(config, defaultConfig);
@@ -83,14 +87,73 @@ module.exports = (gulp, config) => {
 
   tasks.compile.push('icons');
 
-  // Pattern Lab
-  require('./gulp-tasks/gulp-pattern-lab.js')(gulp, config, tasks, browserSync);
+  /**
+   * Accessibility Testing
+   */
+  function pa11yRun(pa11yUrl) {
+    pa11y(pa11yUrl, {
+      includeNotices: true,
+      includeWarnings: true,
+      ignore: [
+        'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
+        'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.1.NoTitleEl',
+        'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
+      ]
+    }).then((results) => {
+      if (results.issues === undefined || results.issues.length < 1) {
+        console.log('[pa11y] No accessibility issues found!');
+      } else {
+        console.log(pa11yCli.results(results));
+      }
+    });
+  }
+
+  function pa11yTest(path) {
+    // Accessibility.
+    const localUrl = browserSync.getOption('urls').get('local');
+    const filePath = path;
+    // Get path past ../_patterns/.
+    const pLPath = filePath.split('_patterns/').pop();
+    // Change remaining path to array.
+    const fileArray = pLPath.split('/');
+
+    // Below is specific to scss files.
+    // Remove last item (get file itself).
+    const fileArrayLast = fileArray.pop();
+    // Get file extension.
+    const fileExtension = fileArrayLast.split('.').pop();
+    if (fileExtension === 'scss') {
+      const fileDir = `${filePath.split('_patterns/')[0]}_patterns/${fileArray.join('/')}`;
+      fs.readdir(fileDir, (err, items) => {
+        items.forEach((item) => {
+          if (item.split('.').pop() === 'twig') {
+            // Change array to string separated by dash.
+            const twigFilePath = `${fileDir}/${item}`;
+            const twigFilePlPath = twigFilePath.split('_patterns/').pop();
+            const filetoArray = twigFilePlPath.split('/');
+            const arraytoPath = filetoArray.join('-');
+            const arraytoPathTweak = arraytoPath.slice(0, -5);
+            pa11yRun(`${localUrl}patterns/${arraytoPathTweak}/${arraytoPathTweak}.html`);
+          }
+        });
+      });
+    } else {
+      // Change array to string separated by dash.
+      const arraytoPath = fileArray.join('-');
+      // Remove file extension.
+      const arraytoPathTweak = arraytoPath.slice(0, -5);
+      pa11yRun(`${localUrl}patterns/${arraytoPathTweak}/${arraytoPathTweak}.html`);
+    }
+  }
 
   // Find open port using portscanner.
   let openPort = '';
   portscanner.findAPortNotInUse(3000, 3010, '127.0.0.1', (error, port) => {
     openPort = port;
   });
+
+  // Pattern Lab
+  require('./gulp-tasks/gulp-pattern-lab.js')(gulp, config, tasks, browserSync, openPort);
 
   /**
    * Task for running browserSync.
@@ -117,8 +180,13 @@ module.exports = (gulp, config) => {
         port: openPort,
       });
     }
-    gulp.watch(config.paths.js, ['scripts']).on('change', browserSync.reload);
-    gulp.watch(`${config.paths.sass}/**/*.scss`, ['css']);
+    gulp.watch(config.paths.js, ['scripts']).on('change', (event) => {
+      browserSync.reload();
+      pa11yTest(event.path);
+    });
+    gulp.watch(`${config.paths.sass}/**/*.scss`, ['css']).on('change', (event) => {
+      pa11yTest(event.path);
+    });
     gulp.watch(config.patternLab.scssToYAML[0].src, ['pl:scss-to-yaml']);
   });
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ngrok": "^2.2.2",
     "node-normalize-scss": "^3.0.0",
     "node-notifier": "^5.1.2",
+    "pa11y": "^5.1.0",
     "portscanner": "^2.1.1",
     "pre-commit": "^1.2.2",
     "psi": "^3.0.0",


### PR DESCRIPTION
Add [pa11y](https://github.com/pa11y/pa11y) accessibility testing on save of twig and scss files. 

### Pull Request Deployment
_If you've never set up Emulsify Gulp for local testing, do the following:_
- Step 1: Clone the Emulsify Gulp repo locally and run `npm link`
- Step 2: Go to your Emulsify installation and run `npm link emulsify-gulp`

### To Test:
- [x] Install [a fresh copy of Emulsify](https://github.com/fourkitchens/emulsify#prototyping-separate-from-drupal-wordpress-etc)
- [x] Save any existing twig or sass files. Verify that you are now getting accessibility feedback in the console
- [x] Do the same for an existing copy, preferably in a client project (you'll need to run step 2 above inside your theme).