### PR TITLE
100: Clean CSS - option to disable or set default options

### DIFF
--- a/gulp-config.js
+++ b/gulp-config.js
@@ -28,13 +28,25 @@
       },
     },
     cssConfig: {
-      enabled: true,
       src: `${themeDir}/components/_patterns/**/*.scss`,
       dest: `${themeDir}/dist/`,
       flattenDestOutput: true,
       lint: {
         enabled: false,
         failOnError: true,
+      },
+      cleanCSS: {
+        enabled: true,
+        options: {
+          compatibility: '*',
+          format: false,
+          inline: 'local',
+          inlineTimeout: 5000,
+          level: 1,
+          rebase: true,
+          sourceMap: false,
+          sourceMapInlineSources: false
+        }
       },
       sourceComments: false,
       sourceMapEmbed: false,

--- a/gulp-tasks/gulp-css.js
+++ b/gulp-tasks/gulp-css.js
@@ -29,7 +29,16 @@ const cleanCSS = require('gulp-clean-css');
         }).on('error', sass.logError))
         .pipe(prefix(cssConfig.autoPrefixerBrowsers))
         .pipe(sourcemaps.init())
-        .pipe(cleanCSS())
+        .pipe(gulpif(cssConfig.cleanCSS.enabled === true, cleanCSS({
+          compatibility: cssConfig.cleanCSS.options.compatibility,
+          format: cssConfig.cleanCSS.options.format,
+          inline: cssConfig.cleanCSS.options.inline,
+          inlineTimeout: cssConfig.cleanCSS.options.inlineTimeout,
+          level: cssConfig.cleanCSS.options.level,
+          rebase: cssConfig.cleanCSS.options.rebase,
+          sourceMap: cssConfig.cleanCSS.options.sourceMap,
+          sourceMapInlineSources: cssConfig.cleanCSS.options.sourceMapInlineSources
+        })))
         .pipe(sourcemaps.write((cssConfig.sourceMapEmbed) ? null : './'))
         .pipe(gulpif(cssConfig.flattenDestOutput, flatten()))
         .pipe(gulp.dest(cssConfig.dest))


### PR DESCRIPTION
Addresses https://github.com/fourkitchens/emulsify-gulp/issues/100

**Description:**
Add the ability to disable CleanCSS entirely or reset some options.

**To Test:**
- Use your preferred method for testing a node module locally (e.g., npm link, setting this branch as your Emulsify package dependency, etc.) to install this branch of Emulsify Gulp in a new or existing Emulsify installation
- Use a local config or test by editing the default config to [disable CleanCSS](https://github.com/fourkitchens/emulsify-gulp/blob/d28976ceb1f695a475a319ca589e6bbb194bc3ef/gulp-config.js#L39)
- Run `yarn start` or `npm start` in your Emulsify instance and verify dist/style.css is not minified
- Test other options as needed