### PR TITLE
105: Exit instructions instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,14 @@ module.exports = (gulp, config) => {
         open: config.browserSync.openBrowserAtStart,
         proxy: config.browserSync.domain,
         startPath: config.browserSync.startPath,
-        ghostMode: config.browserSync.ghostMode
+        ghostMode: config.browserSync.ghostMode,
+        callbacks: {
+          ready: () => {
+            console.log('--------------------------------------------');
+            console.log('Emulsify is Running! (Ctrl-C to Exit Server)');
+            console.log('--------------------------------------------');
+          }
+        }
       });
     } else {
       browserSync.init({
@@ -117,7 +124,14 @@ module.exports = (gulp, config) => {
         open: config.browserSync.openBrowserAtStart,
         reloadOnRestart: config.browserSync.reloadOnRestart,
         port: openPort,
-        ghostMode: config.browserSync.ghostMode
+        ghostMode: config.browserSync.ghostMode,
+        callbacks: {
+          ready: () => {
+            console.log('--------------------------------------------');
+            console.log('Emulsify is Running! (Ctrl-C to Exit Server)');
+            console.log('--------------------------------------------');
+          }
+        }
       });
     }
     gulp.watch(config.paths.js, ['scripts']);


### PR DESCRIPTION
Addresses https://github.com/fourkitchens/emulsify-gulp/issues/105

Instead of providing an `exit` command, which is actually confusing if you still have the terminal window up where you ran `npm start` (looks like it is still running), I have just provided some terminal feedback for how to exit the server.

<img width="391" alt="screen shot 2019-01-29 at 11 35 40 am" src="https://user-images.githubusercontent.com/18293479/51927802-0c5fb980-23ba-11e9-83cc-41fe182a926e.png">
