### PR TITLE
Return gulp streams in tasks.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = (gulp, config) => {
    * Script Task
    */
   gulp.task('scripts', () => {
-    gulp
+    return gulp
       .src(config.paths.js)
       .pipe(sourcemaps.init())
       .pipe(
@@ -57,7 +57,7 @@ module.exports = (gulp, config) => {
    * Task for minifying images.
    */
   gulp.task('imagemin', () => {
-    gulp
+    return gulp
       .src(config.paths.img)
       .pipe(
         imagemin([
@@ -76,7 +76,7 @@ module.exports = (gulp, config) => {
    * Task for generating icon colors/png fallbacks from svg.
    */
   gulp.task('icons', () => {
-    gulp
+    return gulp
       .src('**/*.svg', { cwd: `${config.paths.icons}` })
       .pipe(svgSprite(config.iconConfig))
       .pipe(gulp.dest('.'));


### PR DESCRIPTION
Hi,

I'm doing some interesting manipulation of the gulp tasks, and the ones that are defined by emulsify do not return the gulp streams, so gulp cannot track when those tasks have ended etc.

Adding in some simple return statements does the trick for me.